### PR TITLE
Fix: Install Noto CJK font in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
+RUN apt-get update && apt-get install -y fonts-noto-cjk && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Run the web service on container startup.


### PR DESCRIPTION
The application was failing with an OSError because the `NotoSansCJK-Regular.ttc` font was not found. This change updates the Dockerfile to install the `fonts-noto-cjk` package, which provides the required font.